### PR TITLE
Wrong use of $input->getWord() when posting data after a 'save'

### DIFF
--- a/admin/controllers/resources.php
+++ b/admin/controllers/resources.php
@@ -198,7 +198,7 @@ class ResourcesForm extends PPDForm
 		}
 		foreach($properties as $property)
 		{
-		    $row->$property = JFactory::getApplication()->input->getWord($property);
+		    $row->$property = JFactory::getApplication()->input->getRaw($property);
 		}
 		return $row;
 	}


### PR DESCRIPTION
getWord only allow specific characters and was filtering all data.
The use of the 'Raw' filter has no security consequence here since we operate in the backend.